### PR TITLE
Adding mdspan as future concept

### DIFF
--- a/kratos/tests/cpp_tests/containers/test_mdspan.cpp
+++ b/kratos/tests/cpp_tests/containers/test_mdspan.cpp
@@ -1,0 +1,324 @@
+#include "containers/global_pointers_vector.h" // TODO: Check if this is required, was in another test file.
+#include "includes/mdspan.h"
+#include "testing/testing.h"
+
+namespace Kratos::Testing {
+
+    KRATOS_TEST_CASE(MdspanConstruction) {
+        // 1D mdspan
+        Extents<int, 5> extents1d;
+        std::array<int, 5> data1d = {1, 2, 3, 4, 5};
+        mdspan<int, Extents<int, 5>> mds1d(data1d.data(), extents1d);
+        KRATOS_EXPECT_EQ(mds1d.rank(), 1);
+        KRATOS_EXPECT_EQ(mds1d.extent(0), 5);
+
+        // 2D mdspan with double
+        Extents<int, 2, 3> extents2d_double;
+        std::array<double, 6> data2d_double = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+        mdspan<double, Extents<int, 2, 3>> mds2d_double(data2d_double.data(), extents2d_double);
+        KRATOS_EXPECT_EQ(mds2d_double.rank(), 2);
+        KRATOS_EXPECT_EQ(mds2d_double.extent(0), 2);
+        KRATOS_EXPECT_EQ(mds2d_double.extent(1), 3);
+
+        // 2D mdspan with float
+        Extents<int, 3, 2> extents2d_float;
+        std::array<float, 6> data2d_float = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+        mdspan<float, Extents<int, 3, 2>> mds2d_float(data2d_float.data(), extents2d_float);
+        KRATOS_EXPECT_EQ(mds2d_float.rank(), 2);
+        KRATOS_EXPECT_EQ(mds2d_float.extent(0), 3);
+        KRATOS_EXPECT_EQ(mds2d_float.extent(1), 2);
+
+        // 3D mdspan
+        Extents<int, 2, 3, 4> extents3d;
+        std::array<double, 24> data3d; // Initialize if needed, not strictly necessary for this construction test part
+        mdspan<double, Extents<int, 2, 3, 4>> mds3d(data3d.data(), extents3d);
+        KRATOS_EXPECT_EQ(mds3d.rank(), 3);
+        KRATOS_EXPECT_EQ(mds3d.extent(0), 2);
+        KRATOS_EXPECT_EQ(mds3d.extent(1), 3);
+        KRATOS_EXPECT_EQ(mds3d.extent(2), 4);
+    }
+
+    KRATOS_TEST_CASE(MdspanDataAccess) {
+        // 1D mdspan - int
+        Extents<int, 5> extents1d_int;
+        std::array<int, 5> data1d_int = {1, 2, 3, 4, 5};
+        mdspan<int, Extents<int, 5>> mds1d_int(data1d_int.data(), extents1d_int);
+        KRATOS_EXPECT_EQ(mds1d_int(0), 1);
+        KRATOS_EXPECT_EQ(mds1d_int(4), 5);
+        mds1d_int(2) = 10;
+        KRATOS_EXPECT_EQ(mds1d_int(2), 10);
+
+        // 2D mdspan - double
+        Extents<int, 2, 3> extents2d_double;
+        std::array<double, 6> data2d_double = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+        mdspan<double, Extents<int, 2, 3>> mds2d_double(data2d_double.data(), extents2d_double);
+        KRATOS_EXPECT_DOUBLE_EQ(mds2d_double(0, 0), 1.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds2d_double(1, 2), 6.0);
+        mds2d_double(0, 1) = 7.5;
+        KRATOS_EXPECT_DOUBLE_EQ(mds2d_double(0, 1), 7.5);
+
+        // 2D mdspan - float
+        Extents<int, 3, 2> extents2d_float;
+        std::array<float, 6> data2d_float = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+        mdspan<float, Extents<int, 3, 2>> mds2d_float(data2d_float.data(), extents2d_float);
+        KRATOS_EXPECT_FLOAT_EQ(mds2d_float(0, 0), 1.0f);
+        KRATOS_EXPECT_FLOAT_EQ(mds2d_float(2, 1), 6.0f);
+        mds2d_float(1, 0) = 8.5f;
+        KRATOS_EXPECT_FLOAT_EQ(mds2d_float(1, 0), 8.5f);
+
+        // 3D mdspan - double
+        Extents<int, 2, 2, 2> extents3d_double;
+        std::array<double, 8> data3d_double = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0};
+        mdspan<double, Extents<int, 2, 2, 2>> mds3d_double(data3d_double.data(), extents3d_double);
+        KRATOS_EXPECT_DOUBLE_EQ(mds3d_double(0, 0, 0), 1.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds3d_double(1, 1, 1), 8.0);
+        mds3d_double(0, 1, 0) = 9.5;
+        KRATOS_EXPECT_DOUBLE_EQ(mds3d_double(0, 1, 0), 9.5);
+    }
+
+    KRATOS_TEST_CASE(MdspanLayoutLeftAndRightMapping) {
+        // Layout Left
+        Extents<int, 2, 3> extents_left;
+        std::array<double, 6> data_left = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}; // Column-major
+        layout_left::mapping<Extents<int, 2, 3>> mapping_left(extents_left);
+        mdspan<double, Extents<int, 2, 3>, layout_left> mds_left(data_left.data(), mapping_left);
+
+        KRATOS_EXPECT_DOUBLE_EQ(mds_left(0, 0), 1.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds_left(1, 0), 2.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds_left(0, 1), 3.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds_left(1, 1), 4.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds_left(0, 2), 5.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds_left(1, 2), 6.0);
+
+        // Layout Right
+        Extents<int, 2, 3> extents_right;
+        std::array<double, 6> data_right = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}; // Row-major
+        layout_right::mapping<Extents<int, 2, 3>> mapping_right(extents_right);
+        mdspan<double, Extents<int, 2, 3>, layout_right> mds_right(data_right.data(), mapping_right);
+
+        KRATOS_EXPECT_DOUBLE_EQ(mds_right(0, 0), 1.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds_right(0, 1), 2.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds_right(0, 2), 3.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds_right(1, 0), 4.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds_right(1, 1), 5.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds_right(1, 2), 6.0);
+    }
+
+    KRATOS_TEST_CASE(MdspanLayoutStride) {
+        Extents<int, 2, 3> extents;
+        std::array<double, 12> data = { // Data array is larger to accommodate custom strides
+            1.0, 0.0, 2.0, 0.0, 3.0, 0.0, // Row 0 with stride
+            4.0, 0.0, 5.0, 0.0, 6.0, 0.0  // Row 1 with stride
+        };
+        std::array<int, 2> strides = {6, 2}; // Stride for first dim, stride for second dim
+        layout_stride::mapping<Extents<int, 2, 3>> mapping(extents, strides);
+        mdspan<double, Extents<int, 2, 3>, layout_stride> mds(data.data(), mapping);
+
+        KRATOS_EXPECT_DOUBLE_EQ(mds(0, 0), 1.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds(0, 1), 2.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds(0, 2), 3.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds(1, 0), 4.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds(1, 1), 5.0);
+        KRATOS_EXPECT_DOUBLE_EQ(mds(1, 2), 6.0);
+
+        // Test with non-contiguous elements in the original data due to stride
+        KRATOS_EXPECT_DOUBLE_EQ(data[mapping(0,0)], 1.0);
+        KRATOS_EXPECT_DOUBLE_EQ(data[mapping(0,1)], 2.0); // data[2]
+        KRATOS_EXPECT_DOUBLE_EQ(data[mapping(0,2)], 3.0); // data[4]
+        KRATOS_EXPECT_DOUBLE_EQ(data[mapping(1,0)], 4.0); // data[6]
+        KRATOS_EXPECT_DOUBLE_EQ(data[mapping(1,1)], 5.0); // data[8]
+        KRATOS_EXPECT_DOUBLE_EQ(data[mapping(1,2)], 6.0); // data[10]
+    }
+
+    KRATOS_TEST_CASE(MdspanViewSlice) {
+        Extents<int, 3, 4> extents;
+        std::array<double, 12> data = {
+            1.0, 2.0, 3.0, 4.0,
+            5.0, 6.0, 7.0, 8.0,
+            9.0, 10.0, 11.0, 12.0
+        };
+        mdspan<double, Extents<int, 3, 4>> mds(data.data(), extents);
+
+        // Create a slice: view of the second row (index 1)
+        auto slice = mdspan_view(mds, 1, std::full_extent);
+
+        KRATOS_EXPECT_EQ(slice.rank(), 1);
+        KRATOS_EXPECT_EQ(slice.extent(0), 4);
+        KRATOS_EXPECT_DOUBLE_EQ(slice(0), 5.0);
+        KRATOS_EXPECT_DOUBLE_EQ(slice(1), 6.0);
+        KRATOS_EXPECT_DOUBLE_EQ(slice(2), 7.0);
+        KRATOS_EXPECT_DOUBLE_EQ(slice(3), 8.0);
+
+        // Modify data through slice
+        slice(1) = 60.0;
+        KRATOS_EXPECT_DOUBLE_EQ(mds(1,1), 60.0);
+
+        // Create a slice: view of the second column (index 1)
+        auto col_slice = mdspan_view(mds, std::full_extent, 1);
+        KRATOS_EXPECT_EQ(col_slice.rank(), 1);
+        KRATOS_EXPECT_EQ(col_slice.extent(0), 3);
+        KRATOS_EXPECT_DOUBLE_EQ(col_slice(0), 2.0);
+        KRATOS_EXPECT_DOUBLE_EQ(col_slice(1), 60.0); // Modified value
+        KRATOS_EXPECT_DOUBLE_EQ(col_slice(2), 10.0);
+    }
+
+    KRATOS_TEST_CASE(MdspanViewSubmdspan) {
+        Extents<int, 3, 4> extents;
+        std::array<double, 12> data = {
+            1.0,  2.0,  3.0,  4.0,
+            5.0,  6.0,  7.0,  8.0,
+            9.0, 10.0, 11.0, 12.0
+        };
+        mdspan<double, Extents<int, 3, 4>> mds(data.data(), extents);
+
+        // Create a submdspan: e.g., a 2x2 sub-array starting from mds(1,1)
+        // This would be rows 1-2 and columns 1-2 of the original mdspan
+        auto sub = submdspan(mds, std::pair<int, int>{1, 3}, std::pair<int, int>{1, 3});
+
+        KRATOS_EXPECT_EQ(sub.rank(), 2);
+        KRATOS_EXPECT_EQ(sub.extent(0), 2); // 3-1
+        KRATOS_EXPECT_EQ(sub.extent(1), 2); // 3-1
+
+        KRATOS_EXPECT_DOUBLE_EQ(sub(0,0), 6.0); // Corresponds to mds(1,1)
+        KRATOS_EXPECT_DOUBLE_EQ(sub(0,1), 7.0); // Corresponds to mds(1,2)
+        KRATOS_EXPECT_DOUBLE_EQ(sub(1,0), 10.0); // Corresponds to mds(2,1)
+        KRATOS_EXPECT_DOUBLE_EQ(sub(1,1), 11.0); // Corresponds to mds(2,2)
+
+        // Modify data through submdspan
+        sub(0,0) = 600.0;
+        KRATOS_EXPECT_DOUBLE_EQ(mds(1,1), 600.0);
+
+        // Another submdspan example: first row, first two elements
+        auto sub2 = submdspan(mds, 0, std::pair<int,int>{0,2});
+        KRATOS_EXPECT_EQ(sub2.rank(), 1);
+        KRATOS_EXPECT_EQ(sub2.extent(0), 2);
+        KRATOS_EXPECT_DOUBLE_EQ(sub2(0), 1.0);
+        KRATOS_EXPECT_DOUBLE_EQ(sub2(1), 2.0);
+    }
+
+    KRATOS_TEST_CASE(Mdspan1DViewAlias) {
+        // Test with int
+        std::array<int, 5> data_int = {1, 2, 3, 4, 5};
+        mdspan_1d_view<int> view_int(data_int.data(), data_int.size());
+
+        KRATOS_EXPECT_EQ(view_int.rank(), 1);
+        KRATOS_EXPECT_EQ(view_int.extent(0), 5);
+        KRATOS_EXPECT_EQ(view_int(0), 1);
+        KRATOS_EXPECT_EQ(view_int(2), 3);
+        KRATOS_EXPECT_EQ(view_int(4), 5);
+
+        view_int(1) = 20;
+        KRATOS_EXPECT_EQ(data_int[1], 20);
+        KRATOS_EXPECT_EQ(view_int(1), 20);
+
+        // Test with double
+        std::array<double, 3> data_double = {1.1, 2.2, 3.3};
+        mdspan_1d_view<double> view_double(data_double.data(), data_double.size());
+
+        KRATOS_EXPECT_EQ(view_double.rank(), 1);
+        KRATOS_EXPECT_EQ(view_double.extent(0), 3);
+        KRATOS_EXPECT_DOUBLE_EQ(view_double(0), 1.1);
+        KRATOS_EXPECT_DOUBLE_EQ(view_double(1), 2.2);
+
+        view_double(2) = 33.3;
+        KRATOS_EXPECT_DOUBLE_EQ(data_double[2], 33.3);
+        KRATOS_EXPECT_DOUBLE_EQ(view_double(2), 33.3);
+    }
+
+    KRATOS_TEST_CASE(Mdspan2DViewAlias) {
+        // Test with int, layout_right (default)
+        std::array<int, 6> data_int_lr = {1, 2, 3, 4, 5, 6}; // 2x3 row-major
+        mdspan_2d_view<int, layout_right> view_int_lr(data_int_lr.data(), 2, 3);
+
+        KRATOS_EXPECT_EQ(view_int_lr.rank(), 2);
+        KRATOS_EXPECT_EQ(view_int_lr.extent(0), 2);
+        KRATOS_EXPECT_EQ(view_int_lr.extent(1), 3);
+        KRATOS_EXPECT_EQ(view_int_lr(0,0), 1);
+        KRATOS_EXPECT_EQ(view_int_lr(0,2), 3);
+        KRATOS_EXPECT_EQ(view_int_lr(1,0), 4);
+        KRATOS_EXPECT_EQ(view_int_lr(1,2), 6);
+        view_int_lr(0,1) = 20;
+        KRATOS_EXPECT_EQ(data_int_lr[1], 20);
+        KRATOS_EXPECT_EQ(view_int_lr(0,1), 20);
+
+        // Test with double, layout_left
+        std::array<double, 6> data_double_ll = {1.1, 4.4, 2.2, 5.5, 3.3, 6.6}; // 2x3 column-major
+        mdspan_2d_view<double, layout_left> view_double_ll(data_double_ll.data(), 2, 3);
+
+        KRATOS_EXPECT_EQ(view_double_ll.rank(), 2);
+        KRATOS_EXPECT_EQ(view_double_ll.extent(0), 2);
+        KRATOS_EXPECT_EQ(view_double_ll.extent(1), 3);
+        KRATOS_EXPECT_DOUBLE_EQ(view_double_ll(0,0), 1.1);
+        KRATOS_EXPECT_DOUBLE_EQ(view_double_ll(1,0), 4.4);
+        KRATOS_EXPECT_DOUBLE_EQ(view_double_ll(0,2), 3.3);
+        KRATOS_EXPECT_DOUBLE_EQ(view_double_ll(1,2), 6.6);
+        view_double_ll(0,1) = 22.2; // data_double_ll[2] for layout_left
+        KRATOS_EXPECT_DOUBLE_EQ(data_double_ll[2], 22.2);
+        KRATOS_EXPECT_DOUBLE_EQ(view_double_ll(0,1), 22.2);
+
+        // Test with default layout (layout_right) by not specifying it
+        std::array<float, 4> data_float_def = {1.0f, 2.0f, 3.0f, 4.0f}; // 2x2 row-major
+        mdspan_2d_view<float> view_float_def(data_float_def.data(), 2, 2);
+        KRATOS_EXPECT_EQ(view_float_def.rank(), 2);
+        KRATOS_EXPECT_EQ(view_float_def.extent(0), 2);
+        KRATOS_EXPECT_EQ(view_float_def.extent(1), 2);
+        KRATOS_EXPECT_FLOAT_EQ(view_float_def(0,0), 1.0f);
+        KRATOS_EXPECT_FLOAT_EQ(view_float_def(1,1), 4.0f);
+    }
+
+    KRATOS_TEST_CASE(MdspanStreamOperator) {
+        std::ostringstream oss;
+
+        // 1D mdspan
+        Extents<int, 5> extents1d;
+        std::array<int, 5> data1d = {1, 2, 3, 4, 5};
+        mdspan<int, Extents<int, 5>> mds1d(data1d.data(), extents1d);
+        oss << mds1d;
+        KRATOS_EXPECT_STREQ(oss.str().c_str(), "mdspan with extents: (5)");
+        oss.str(""); // Clear the stream
+        oss.clear();
+
+        // 2D mdspan with layout_right (default for this constructor)
+        Extents<int, 2, 3> extents2d;
+        std::array<double, 6> data2d = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+        mdspan<double, Extents<int, 2, 3>> mds2d(data2d.data(), extents2d);
+        oss << mds2d;
+        KRATOS_EXPECT_STREQ(oss.str().c_str(), "mdspan with extents: (2, 3)");
+        oss.str("");
+        oss.clear();
+
+        // 2D mdspan with layout_left
+        Extents<int, 3, 2> extents2d_ll; // Different extents to ensure differentiation
+        std::array<float, 6> data2d_ll = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+        layout_left::mapping<Extents<int, 3, 2>> mapping2d_ll(extents2d_ll);
+        mdspan<float, Extents<int, 3, 2>, layout_left> mds2d_ll(data2d_ll.data(), mapping2d_ll);
+        oss << mds2d_ll;
+        KRATOS_EXPECT_STREQ(oss.str().c_str(), "mdspan with extents: (3, 2)");
+        oss.str("");
+        oss.clear();
+
+        // 3D mdspan
+        Extents<int, 2, 3, 4> extents3d;
+        std::array<double, 24> data3d; // Data initialization not needed for this test
+        mdspan<double, Extents<int, 2, 3, 4>> mds3d(data3d.data(), extents3d);
+        oss << mds3d;
+        KRATOS_EXPECT_STREQ(oss.str().c_str(), "mdspan with extents: (2, 3, 4)");
+        oss.str("");
+        oss.clear();
+
+        // mdspan_1d_view alias
+        mdspan_1d_view<int> view1d(data1d.data(), data1d.size());
+        oss << view1d;
+        KRATOS_EXPECT_STREQ(oss.str().c_str(), "mdspan with extents: (5)");
+        oss.str("");
+        oss.clear();
+
+        // mdspan_2d_view alias with layout_right
+        mdspan_2d_view<double, layout_right> view2d_lr(data2d.data(), 2, 3);
+        oss << view2d_lr;
+        KRATOS_EXPECT_STREQ(oss.str().c_str(), "mdspan with extents: (2, 3)");
+        oss.str("");
+        oss.clear();
+    }
+
+} // namespace Kratos::Testing


### PR DESCRIPTION
This commit introduces C++ tests for the mdspan functionalities available in `kratos/includes/mdspan.h`.

The tests cover:
- Construction of mdspan objects with various ranks, data types, and layouts.
- Data access and modification for mdspan objects.
- Behavior of different layouts: `layout_left`, `layout_right`, and `layout_stride`.
- Slicing and submdspan capabilities of `mdspan_view`.
- Correctness of `mdspan_1d_view` and `mdspan_2d_view` aliases.
- Output formatting of the `mdspan` stream operator.

The new test file is located at `kratos/tests/cpp_tests/containers/test_mdspan.cpp`.

**📝 Description**
A brief description of the PR.

Please mark the PR with appropriate tags: 
- Api Breaker, Mpi, etc...

**🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Added feature X to Y
- Added Foo Application
- Fixed X (#XXXX Reference to issue if apply) 
- etc...
