### PR TITLE
[Doc] Add `CLAUDE.md` documentation for various applications

### DIFF
--- a/applications/CoSimulationApplication/CLAUDE.md
+++ b/applications/CoSimulationApplication/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md — CoSimulationApplication
+
+> Application-specific guidance. Inherits everything in the root `/CLAUDE.md`; only the
+> co-simulation specifics are documented here. Read the root file first for global conventions.
+
+## Purpose
+
+The **CoSimulationApplication** couples black-box solvers and external software tools
+(Kratos↔Kratos, Kratos↔external) into partitioned multi-physics simulations (FSI, thermal,
+etc.). It is **predominantly a Python application**: the orchestration (coupled solvers,
+convergence accelerators, predictors, data-transfer operators) lives in `python_scripts/`,
+while the C++ core mostly provides the `CoSimIO` communication layer and a few utilities.
+
+Kratos↔Kratos coupling has no data-duplication overhead (same database). Mapping between
+non-matching grids is delegated to the **MappingApplication**.
+
+## Dependencies
+
+- **KratosCore** (always).
+- **MappingApplication** — for mapping between non-matching interfaces.
+- **CoSimIO** — vendored in `custom_external_libraries/` (the detached communication library,
+  also usable from non-Kratos codes).
+- Domain solvers as needed: **FluidDynamics**, **StructuralMechanics**, etc. (Kratos wrappers),
+  or any external solver via its wrapper.
+- Optional **MPI** (`mpi_extension/`) — independent of whether the coupled solvers run in MPI.
+
+## Directory layout (application-specific, mostly Python)
+
+```
+python_scripts/
+  co_simulation_analysis.py        # CoSimulationAnalysis — top-level driver (AnalysisStage)
+  MainKratosCoSim.py               # main script entry point
+  base_classes/                    # CoSimulationSolverWrapper, CoSimulationCoupledSolver, …
+  solver_wrappers/                 # one subpackage per coupled solver/tool:
+    kratos/        #   Kratos solver wrappers (fluid, structural, …)
+    external/      #   generic external-solver wrapper (via CoSimIO)
+    sdof/          #   single-DOF analytical solvers
+    rigid_body/    #   rigid-body solver
+    cpp_ping_pong/ #   C++ example/test wrapper
+  coupled_solvers/                 # coupling algorithms:
+    gauss_seidel_strong/weak.py, jacobi_strong/weak.py, block_strong.py,
+    feti_dynamic_coupled_solver.py
+  convergence_accelerators/        # Aitken, MVQN, IQN-ILS, constant relaxation, …
+  convergence_criteria/            # residual / relative criteria for the coupling loop
+  predictors/                      # interface predictors (linear, quadratic, …)
+  data_transfer_operators/         # kratos_mapping (uses MappingApplication), copy, …
+  coupling_operations/             # scaling, reaction computation, etc.
+  coupling_interface_data.py       # CouplingInterfaceData — the data exchanged across the interface
+  factories/, helpers/, processes/, utilities/
+custom_io/        # C++ CoSimIO interface wrappers
+custom_processes/ # C++ helper processes
+custom_utilities/ # C++ helpers
+custom_python/    # bindings incl. add_co_sim_io_to_python.cpp
+custom_external_libraries/  # vendored CoSimIO — DO NOT modify
+mpi_extension/    # MPI build additions
+tests/
+  cpp_tests/      # GTest + co_simulation_fast_suite.{h,cpp}
+  test_CoSimulationApplication.py
+```
+
+## Build
+
+- CMake libs: `KratosCoSimulationCore` (SHARED) and `KratosCoSimulationApplication` (pybind11).
+- Compile definition: `CO_SIMULATION_APPLICATION=EXPORT,API`.
+- `CoSimIO` is built from `custom_external_libraries/` — treat as vendored (don't modify).
+- `mpi_extension/` added under MPI builds.
+
+## Configuration & usage
+
+Co-simulations are driven entirely by a **JSON** config describing solvers, the coupled
+solver (algorithm), coupling interfaces, data-transfer operators, convergence accelerator and
+criteria. Run via `MainKratosCoSim.py` with that JSON, or instantiate `CoSimulationAnalysis`.
+
+Key extension interface — to couple a **new solver/tool**, implement a `SolverWrapper`
+(subclass of `CoSimulationSolverWrapper` in `base_classes/`) exposing at least:
+`Initialize`, `AdvanceInTime`, `InitializeSolutionStep`, `Predict`, `SolveSolutionStep`,
+`FinalizeSolutionStep`, `Finalize`, plus `ImportCouplingInterface*`/`Export*` data hooks.
+External (non-Kratos) tools connect through the **CoSimIO** library / the `external` wrapper.
+
+## Testing
+
+- **C++ fixture:** `KratosCoSimulationFastSuite` (`co_simulation_fast_suite.h`); generic tests
+  use `KratosCoreFastSuite`.
+- **Python:** `test_CoSimulationApplication.py` is the suite entry point — register new
+  `test_*.py` there. Many tests use the `sdof`/`rigid_body` analytical wrappers and the
+  `cpp_ping_pong` example to exercise the coupling loop without heavy solvers.
+
+## Conventions & gotchas
+
+- Logic lives in **Python**; keep the C++ side thin (CoSimIO + utilities). New coupling
+  features (accelerators, predictors, operators) are Python subclasses registered via the
+  corresponding `factories/`.
+- Strong vs. weak coupling = with/without inner convergence loop (`*_strong` vs `*_weak`
+  coupled solvers); choose the matching convergence accelerator/criteria.
+- Data exchange is via `CouplingInterfaceData` (a named variable on a ModelPart interface);
+  map mismatched meshes with the `kratos_mapping` data-transfer operator (MappingApplication).
+- MPI of the coupling is independent of MPI inside each solver — don't conflate them.

--- a/applications/ConstitutiveLawsApplication/CLAUDE.md
+++ b/applications/ConstitutiveLawsApplication/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md — ConstitutiveLawsApplication
+
+> Application-specific guidance. Inherits everything in the root `/CLAUDE.md`; only the
+> constitutive-law specifics are documented here. Read the root file first for global conventions.
+> The user (Vicente Mataix Ferrándiz) is one of the authors of this application.
+
+## Purpose
+
+The **ConstitutiveLawsApplication** is the central library of **material models** for Kratos
+solid mechanics. It hosts hyperelastic laws, small- and finite-strain plasticity and damage,
+thermal and composite laws, and the generic templated machinery (yield surfaces × plastic
+potentials, integrators) that combines them. It is the natural companion of the
+**StructuralMechanicsApplication**, which provides the elements that call these laws.
+
+The laws are heavily **template-based**: e.g. small-strain isotropic plasticity is
+`SmallStrainIsotropicPlasticity3D<YieldSurface, PlasticPotential>`, instantiated for all
+combinations of VonMises / ModifiedMohrCoulomb / Tresca / DruckerPrager (and more). The
+`constitutive_laws_application.cpp` registers ~hundreds of concrete instantiations
+(≈480 `KRATOS_REGISTER_*` calls).
+
+## Dependencies
+
+- **KratosCore** (always).
+- **StructuralMechanicsApplication** — provides the constitutive-law base infrastructure
+  (`ConstitutiveLaw`, strain/stress utilities) and the elements that drive these laws; it is
+  effectively a co-dependency for real simulations.
+
+## Directory layout (application-specific)
+
+```
+custom_constitutive/
+  small_strains/      # small-strain elastic, plasticity, damage, viscous laws
+  finite_strains/     # hyperelastic (Neo-Hookean, Kirchhoff) + finite-strain plasticity
+  composites/         # rule-of-mixtures, serial-parallel, orthotropic composite laws
+  thermal/            # thermo-mechanical laws
+  structural_elements_constitutive_laws/  # truss/beam/cable/membrane 1D & plane laws
+  auxiliary_files/    # yield surfaces, plastic potentials, integrators, table_keys, helpers
+custom_processes/     # material-state / damage / fatigue support processes
+custom_utilities/     # tangent-operator, advanced constitutive-law utilities
+custom_python/        # bindings: add_custom_constitutive_laws/processes/utilities_to_python
+python_scripts/       # high_cycle_fatigue_analysis.py, pre-stress/damage helper processes,
+  symbolic_generation/   #   sympy generators for symbolic laws
+tests/
+  cpp_tests/          # GTest + constitutive_laws_fast_suite.{h,cpp}
+  test_ConstitutiveLawsApplication.py
+```
+
+## Build
+
+- CMake libs: `KratosConstitutiveLawsCore` (SHARED) and `KratosConstitutiveLawsApplication`
+  (pybind11). Compile definition: `CONSTITUTIVE_LAWS_APPLICATION=EXPORT,API`.
+- Sources auto-globbed from `custom_*` — new `.cpp` files are picked up automatically.
+- This is a **heavy compilation unit** (many template instantiations); unity builds help.
+
+## Authoring a constitutive law
+
+A `ConstitutiveLaw` subclass typically overrides:
+
+```cpp
+void CalculateMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues) override;
+void CalculateMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues) override;
+void InitializeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues) override;
+void FinalizeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues) override;
+SizeType GetStrainSize() const override;
+int Check(const Properties&, const GeometryType&, const ProcessInfo&) const override;
+```
+
+- Stress/strain measures (PK2, Cauchy, Kirchhoff) and the `Flags` on
+  `ConstitutiveLaw::Parameters` (`COMPUTE_STRESS`, `COMPUTE_CONSTITUTIVE_TENSOR`) decide what
+  must be filled. Respect the requested flags.
+- Plasticity/damage laws compose a **yield surface** + **plastic potential** + **integrator**
+  from `auxiliary_files/` via templates — prefer adding a new yield surface/potential and
+  instantiating, over writing a monolithic law.
+- Material parameters come from `Properties` (the `StructuralMaterials.json`), often through
+  `Table`s for nonlinear/temperature-dependent data.
+
+## Registration (critical)
+
+- Every concrete law must be registered with `KRATOS_REGISTER_CONSTITUTIVE_LAW("Name", instance)`
+  in `constitutive_laws_application.cpp`, and the **template instantiation** must exist.
+  Forgetting either makes the law invisible to `StructuralMaterials.json`.
+- New variables → `constitutive_laws_application_variables.{h,cpp}`.
+
+## Testing
+
+- **C++ fixture:** `KratosConstitutiveLawsFastSuite` (`constitutive_laws_fast_suite.h`);
+  generic tests use `KratosCoreFastSuite`.
+- **Python:** `test_ConstitutiveLawsApplication.py` is the suite entry point — register new
+  `test_*.py` there. Many laws are validated by single-point integration drivers.
+
+## Conventions & gotchas
+
+- Some laws are **symbolically generated** (`python_scripts/symbolic_generation/`) — edit the
+  generator and regenerate; don't hand-patch generated tangent/stress code.
+- Keep `GetStrainSize()` consistent with the law's dimension (3 → 2D plane, 6 → 3D, etc.).
+- The base `ConstitutiveLaw` interface lives in **KratosCore**; the structural-specific helpers
+  live in **StructuralMechanicsApplication** — build both when testing real elements.

--- a/applications/FluidDynamicsApplication/CLAUDE.md
+++ b/applications/FluidDynamicsApplication/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md — FluidDynamicsApplication
+
+> Application-specific guidance. Inherits everything in the root `/CLAUDE.md`; only the
+> fluid-dynamics specifics are documented here. Read the root file first for global
+> C++/Python/pybind11/testing conventions.
+
+## Purpose
+
+The **FluidDynamicsApplication** holds the core Computational Fluid Dynamics (CFD)
+developments of Kratos: stabilized FEM solvers for **incompressible**,
+**weakly-compressible** and **compressible** flow, on linear elements, in 2D/3D
+(plus limited 2D axisymmetric). It supports ALE mesh motion (with MeshMovingApplication)
+and MPI parallelism (with Metis + Trilinos).
+
+Key formulations: **VMS** (quasi-static & dynamic subscales), **Orthogonal SubScales
+(OSS)**, **FIC**; Newtonian and non-Newtonian (Bingham, Herschel-Bulkley) constitutive
+models; embedded/two-fluid (level-set) formulations; explicit compressible Navier-Stokes
+in conservative variables with shock capturing.
+
+## Dependencies
+
+- **KratosCore** (always).
+- **LinearSolversApplication** — practical default for the algebraic solvers.
+- **MeshMovingApplication** — ALE / moving-mesh fluid solvers.
+- **TrilinosApplication + MetisApplication** — MPI (`trilinos_*` solvers, `trilinos_extension/`).
+- Optional companions: **FSIApplication / CoSimulationApplication** (coupled problems),
+  **HDF5Application** (I/O), **MappingApplication**.
+
+## Directory layout (application-specific)
+
+```
+custom_elements/        # ~35 element .cpp: VMS, QSVMS, DVMS, FIC, fractional-step,
+  data_containers/      #   weakly-compressible, two-fluid, embedded, low-Mach, compressible NS
+custom_conditions/      # inlet/outlet/wall/slip/Neumann conditions, monolithic wall conditions
+custom_constitutive/    # fluid constitutive laws (Newtonian 2D/3D, Bingham, Herschel-Bulkley, …)
+custom_processes/       # embedded, distance, mass conservation, drag, slip, wall-law processes
+custom_strategies/      # fractional-step & monolithic strategies, schemes, B&S
+custom_response_functions/  # adjoint fluid response functions (drag, …)
+custom_utilities/       # compiled FIRST (used inside element cpps): fluid math, statistics, drag utils
+custom_python/          # pybind11 bindings
+automatic_differentiation/  # sympy generators for the symbolic element variants
+trilinos_extension/     # MPI bindings/strategies (built only with USE_MPI + TRILINOS_FOUND)
+python_scripts/         # analysis stages, solvers, processes (see below)
+tests/
+  cpp_tests/            # GTest + fluid_dynamics_fast_suite.{h,cpp}
+  test_FluidDynamicsApplication.py
+```
+
+## Build
+
+- CMake libs: `KratosFluidDynamicsCore` (SHARED) and `KratosFluidDynamicsApplication` (pybind11).
+- **Source ordering matters:** `custom_utilities/*.cpp` is globbed *before* `custom_elements/*.cpp`
+  in `CMakeLists.txt` because utilities are used inside the element translation units. Keep this order.
+- Compile definition: `FLUID_DYNAMICS_APPLICATION=EXPORT,API`.
+- `automatic_differentiation/` is installed into the Python package; `python_registry_lists.py`
+  is installed alongside `__init__.py`.
+- The `trilinos_extension` subdirectory is added only when `USE_MPI=ON AND TRILINOS_FOUND`.
+
+## Python entry points
+
+- **Analysis stage:** `fluid_dynamics_analysis.py` → `FluidDynamicsAnalysis`
+  (RVE variant: `fluid_dynamics_analysis_rve.py`; adjoint: `adjoint_fluid_analysis.py`).
+- **Solver wrapper:** `python_solvers_wrapper_fluid.py` (and `python_solvers_wrapper_adjoint_fluid.py`)
+  dispatch on `solver_type`. Solver base: `fluid_solver.py` (`FluidSolver`).
+- **Solver families:**
+  - `navier_stokes_solver_vmsmonolithic.py` (monolithic VMS — the workhorse)
+  - `navier_stokes_solver_fractionalstep.py` (segregated fractional step, VMS only)
+  - `navier_stokes_two_fluids_solver.py` (level-set two-fluid)
+  - `navier_stokes_embedded_solver.py` (embedded/immersed boundary)
+  - `navier_stokes_compressible_explicit_solver.py`, `navier_stokes_low_mach_solver.py`
+  - `navier_stokes_ale_fluid_solver.py` (moving mesh), `navier_stokes_monolithic_iga_solver.py`
+  - `stokes_solver_monolithic.py`, `adjoint_monolithic_solver.py`
+  - `trilinos_*` variants for MPI
+- Boundary conditions / post-processing are applied via the many `apply_*_process.py` and
+  `compute_*_process.py` modules (inlet, outlet, slip, no-slip, wall law, drag, CFL, y+, …).
+
+## Testing
+
+- **C++ fixture:** tests primarily use `KratosCoreFastSuite`; the application fixture is
+  `fluid_dynamics_fast_suite.{h,cpp}`.
+- **Python:** `test_FluidDynamicsApplication.py` builds `small`/`night`/`validation`/`all`
+  suites — register any new `test_*.py` there.
+
+## Conventions & gotchas
+
+- Elements rely on `ProcessInfo` for stabilization constants, `OSS_SWITCH`, `DYNAMIC_TAU`,
+  time-integration parameters — make sure these are set by the scheme/solver, not the element.
+- Many elements are **symbolically generated** from `automatic_differentiation/`; edit the
+  generator and regenerate rather than hand-editing the generated `Calculate*` bodies.
+- DOFs: `VELOCITY` + `PRESSURE` (monolithic) or staggered (fractional step). Two-fluid/embedded
+  use `DISTANCE`. Compressible uses conservative variables (`DENSITY`, `MOMENTUM`, `TOTAL_ENERGY`).
+- New variables → `fluid_dynamics_application_variables.h` (define) +
+  `fluid_dynamics_application.cpp` (register), where elements/conditions are also registered.
+- Keep MPI tests consistent with CI (`OMP_NUM_THREADS=1`).

--- a/applications/LinearSolversApplication/CLAUDE.md
+++ b/applications/LinearSolversApplication/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md — LinearSolversApplication
+
+> Application-specific guidance. Inherits everything in the root `/CLAUDE.md`; only the
+> linear-solver specifics are documented here. Read the root file first for global conventions.
+
+## Purpose
+
+The **LinearSolversApplication** is a thin Kratos wrapper around the **Eigen** linear algebra
+library (and the **Spectra** eigensolver library), exposing direct/iterative sparse solvers,
+dense solvers, decompositions and eigenvalue solvers to Kratos. It is the de-facto default
+provider of robust direct solvers for most applications, so it is a near-universal dependency.
+
+## Provided solvers (Python `solver_type`)
+
+**Sparse direct/iterative** (`custom_solvers/eigen_sparse_*`): `sparse_lu`, `sparse_qr`,
+`sparse_cg`, complex variants (`sparse_lu_complex`), and — with Intel MKL — `pardiso_llt`,
+`pardiso_ldlt`, `pardiso_lu` (+ complex). With SuiteSparse: `cholmod`, `umfpack`, `spqr`
+(+ complex). (In project parameters these are usually prefixed `eigen_`, e.g. `eigen_sparse_lu`.)
+
+**Dense direct** (`custom_solvers/eigen_dense_*`): `dense_col_piv_householder_qr`,
+`dense_householder_qr`, `dense_llt`, `dense_partial_piv_lu` (+ complex variants).
+
+**Eigenvalue** (`eigensystem_solver`, `spectra_sym_g_eigs_shift_solver`,
+`feast_eigensystem_solver`, `eigen_dense_eigenvalue_solver`): generalized symmetric eigenvalue
+problems (modal analysis), with FEAST available only when built against MKL.
+
+## Dependencies
+
+- **KratosCore** (always).
+- **Eigen** — vendored in `external_libraries/eigen3` (compiled with `EIGEN_MPL2_ONLY`).
+- **Spectra** — vendored in `external_libraries/spectra1`.
+- Optional **Intel MKL** (`USE_EIGEN_MKL=ON`) — Pardiso solvers + FEAST.
+- Optional **SuiteSparse** (`USE_EIGEN_SUITESPARSE=ON`) — CHOLMOD/UMFPACK/SPQR.
+- Optional **FEAST4** (`USE_EIGEN_FEAST=ON`, Linux + MKL only).
+
+## Directory layout (application-specific)
+
+```
+custom_solvers/        # eigen_sparse_*, eigen_dense_*, eigensystem_solver, feast_*, spectra_*
+custom_decompositions/ # dense matrix decompositions exposed to Python
+custom_factories/      # dense_linear_solver_factory.cpp (registered dense solver factory)
+custom_utilities/      # MKL helpers (mkl_utilities.cpp, only with USE_EIGEN_MKL)
+custom_python/         # bindings: add_custom_solvers/decompositions/utilities_to_python
+external_libraries/    # eigen3, spectra1 (and FEAST when enabled) — DO NOT modify
+python_scripts/        # dense_linear_solver_factory.py
+tests/                 # Python tests only (no GTest fast-suite in this app)
+```
+
+## Build
+
+- CMake libs: `KratosLinearSolversCore` (SHARED) and `KratosLinearSolversApplication` (pybind11).
+- Built differently from most apps: sources are added with `target_sources` (not a single
+  GLOB of `custom_*`). The core registers solver factories; most solvers are header-only
+  (`custom_solvers/*.h`) and instantiated through the factory.
+- Compile definitions: `LINEARSOLVERS_APPLICATION=EXPORT,API`, plus `EIGEN_MPL2_ONLY` (PUBLIC).
+- **MKL** (`USE_EIGEN_MKL`): needs `MKLROOT` (or a Conda env); adds
+  `mkl_smoother_base.cpp`, `mkl_ilu.cpp`, `mkl_utilities.cpp` and defines
+  `USE_EIGEN_MKL`/`EIGEN_USE_MKL_ALL`.
+- **SuiteSparse** (`USE_EIGEN_SUITESPARSE`): runs the bundled `FindCHOLMOD/SPQR/UMFPACK`
+  cmake modules and defines `KRATOS_USE_EIGEN_SUITESPARSE`.
+- **FEAST** requires MKL and is Linux-only.
+
+## Python usage
+
+```json
+{ "solver_type": "eigen_sparse_lu" }
+```
+
+- Standard `linear_solver_settings` blocks accept these `solver_type`s; other applications
+  list this app as a dependency to get them.
+- `dense_linear_solver_factory.py` builds dense solvers for small/local systems.
+
+## Testing
+
+- **Python only**: `test_LinearSolversApplication.py` is the suite entry point, aggregating
+  `test_eigen_direct_solver`, `test_eigen_dense_*`, `test_eigensystem_solver`,
+  `test_feast_eigensystem_solver`, `test_mkl`, etc. Register new `test_*.py` there.
+- MKL/SuiteSparse/FEAST tests skip themselves when the corresponding backend isn't compiled in.
+- There is **no C++ GTest fast-suite** in this application.
+
+## Conventions & gotchas
+
+- **Never modify `external_libraries/`** (Eigen, Spectra, FEAST) — they are vendored.
+- Solvers are exposed by **registering them in the factory**; adding a header in
+  `custom_solvers/` is not enough — wire it into the (dense or sparse) factory and the
+  pybind bindings.
+- Complex-domain solvers are separate types (`*_complex`); keep real/complex paths distinct.
+- Respect the `EIGEN_MPL2_ONLY` constraint — do not pull in non-MPL2 Eigen modules.

--- a/applications/MappingApplication/CLAUDE.md
+++ b/applications/MappingApplication/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md — MappingApplication
+
+> Application-specific guidance. Inherits everything in the root `/CLAUDE.md`; only the
+> mapping specifics are documented here. Read the root file first for global conventions.
+
+## Purpose
+
+The **MappingApplication** transfers nodal data between **non-matching grids**. It works in
+serial, shared memory (OpenMP) and distributed memory (**MPI**), across 1D/2D/3D domains and
+matching or non-matching meshes. It is the mapping backend used by the
+CoSimulationApplication (via `KratosMappingDataTransferOperator`).
+
+A `Mapper` maps nodal data from an **Origin** `ModelPart` to a **Destination** `ModelPart`,
+configured with `Kratos::Parameters`. Mappers are always built through the **`MapperFactory`**
+(serial) or `MPIMapperFactory` (distributed) — never constructed directly.
+
+## Available mappers
+
+Built from `custom_mappers/`:
+
+- `nearest_neighbor_mapper` — nearest neighbor (+ IGA variant `nearest_neighbor_mapper_iga`).
+- `nearest_element_mapper` — projects onto the nearest element/condition (shape-function based).
+- `barycentric_mapper` — barycentric interpolation.
+- `radial_basis_function_mapper` — RBF mapping.
+- `beam_mapper` — structural beam mapping (translations + rotations).
+- `coupling_geometry_mapper` — mortar-style mapping on a coupling geometry.
+- `projection_3D_2D_mapper` — metamapper deriving a 3D destination solution from a 2D origin.
+- `interpolative_mapper_base` — shared base for the interpolation-type mappers.
+
+## Dependencies
+
+- **KratosCore** — serial / shared-memory build has no other dependency.
+- **TrilinosApplication** (+ MPI) — required for the distributed build (`mpi_extension/`),
+  which uses Trilinos distributed matrices/vectors. Most MPI solvers in Kratos depend on it.
+
+## Directory layout (application-specific)
+
+```
+custom_mappers/      # the Mapper implementations listed above
+custom_searching/    # interface object search (bins/octree based neighbor location)
+custom_utilities/    # mapping matrix utilities, interface communicators, vector containers
+custom_modelers/     # Modelers that build mapping/coupling geometries
+custom_python/       # pybind11 bindings (add_custom_mappers_*, add_custom_utilities_*)
+mpi_extension/       # MPI/Trilinos mapper backend (built only with USE_MPI + TRILINOS_FOUND)
+python_scripts/      # python_mapper_factory.py, python_mapper.py, helpers
+tests/
+  cpp_tests/         # GTest + mapping_fast_suite.{h,cpp}
+  test_MappingApplication.py
+```
+
+## Build
+
+- CMake libs: `KratosMappingCore` (SHARED) and `KratosMappingApplication` (pybind11).
+- Core sources use plain `file(GLOB ...)` (non-recursive) over `custom_mappers`,
+  `custom_searching`, `custom_utilities`, `custom_modelers`.
+- Compile definition: `MAPPING_APPLICATION=EXPORT,API`.
+- **Unity-build gotcha:** `custom_utilities/mapping_matrix_utilities.cpp` and
+  `interface_vector_container.cpp` are explicitly excluded from unity builds — keep that
+  exclusion when touching these files.
+- C++ tests use `USE_CUSTOM_MAIN` in `kratos_add_gtests`.
+- `mpi_extension` subdir added only when `USE_MPI=ON AND TRILINOS_FOUND`.
+
+## Python usage
+
+```python
+from KratosMultiphysics.MappingApplication import python_mapper_factory
+mapper = python_mapper_factory.CreateMapper(origin_model_part, destination_model_part, mapper_settings)
+mapper.Map(ORIGIN_VARIABLE, DESTINATION_VARIABLE)        # origin -> destination
+mapper.InverseMap(DESTINATION_VARIABLE, ORIGIN_VARIABLE) # destination -> origin
+```
+
+- `mapper_settings["mapper_type"]` selects the mapper (`"nearest_neighbor"`,
+  `"nearest_element"`, `"barycentric"`, `"coupling_geometry"`, …).
+- Behavior is customized with **flags** (e.g. `ADD_VALUES`, `SWAP_SIGN`, `USE_TRANSPOSE`,
+  `TO_NON_HISTORICAL`/`FROM_NON_HISTORICAL`) passed to `Map`/`InverseMap`.
+- For MPI, use the MPI factory; ModelParts may live on a subset of ranks.
+
+## Testing
+
+- **C++ fixture:** `KratosMappingFastSuite` (`mapping_fast_suite.h`); core-only tests use
+  `KratosCoreFastSuite`.
+- **Python:** `test_MappingApplication.py` is the suite entry point — register new
+  `test_*.py` there. MPI tests run separately.
+
+## Conventions & gotchas
+
+- Always go through the factory; the mapper builds an interface search + a mapping matrix.
+- The mapping matrix is reusable: rebuild it (`UpdateInterface`) when geometry changes,
+  otherwise reuse it for repeated `Map` calls.
+- New variables → `mapping_application_variables.{h,cpp}`.
+- Keep serial and MPI mapper behavior in sync; the MPI variant lives in `mpi_extension/`.

--- a/applications/MeshingApplication/CLAUDE.md
+++ b/applications/MeshingApplication/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md — MeshingApplication
+
+> Application-specific guidance. Inherits everything in the root `/CLAUDE.md`; only the
+> meshing specifics are documented here. Read the root file first for global conventions.
+> The user (Vicente Mataix Ferrándiz) is the main author of the MMG integration.
+
+## Purpose
+
+The **MeshingApplication** provides tools to create, manipulate, remesh and interpolate
+between meshes. It wraps several third-party meshers/remeshers (**Triangle**, **TetGen**,
+**MMG/ParMMG**) and provides metric-computation processes (level-set, Hessian, error-based)
+that drive anisotropic adaptive remeshing, plus utilities to transfer/interpolate nodal and
+internal (Gauss-point) variables between old and new meshes.
+
+## Dependencies
+
+- **KratosCore** (always).
+- **StructuralMechanicsApplication** — included at configure time (its source dir is on the
+  include path); internal-variable interpolation reuses structural constitutive infrastructure.
+- **Triangle** — vendored in `external_libraries/triangle` (core), always available.
+- **TetGen** — optional, non-free TPL (`USE_TETGEN_NONFREE_TPL=ON`).
+- **MMG** (2D/3D/S) — optional serial anisotropic remesher (`INCLUDE_MMG=ON`, needs `MMG_ROOT`).
+- **ParMMG** — optional MPI remesher (`INCLUDE_PMMG=ON`, requires `USE_MPI=ON` **and** `INCLUDE_MMG=ON`).
+
+## Directory layout (application-specific)
+
+```
+custom_processes/
+  metrics_levelset_process.h   # level-set based metric
+  metrics_hessian_process.h    # Hessian (solution-based) metric
+  metrics_error_process.h      # error-estimation metric
+  metric_fast_init_process.h, set_h_map_process.h
+  nodal_values_interpolation_process.h / internal_variables_interpolation_process.h
+  multiscale_refining_process.h, embedded_mesh_locator_process.h
+  mmg/      # MmgProcess (2D/3D/Surface remeshing) — built when INCLUDE_MMG=ON
+  parmmg/   # ParMmgProcess (distributed remeshing) — built when INCLUDE_PMMG=ON
+custom_utilities/   # mesh transfer (MeshTransfer, BinBasedMeshTransfer), meshers, mmg/ & parmmg/ utilities
+custom_includes/    # shared headers / mesher data structures
+custom_io/          # PFEMGidIO and mmg/ IO; MMG file readers/writers
+custom_external_libraries/tetMeshOpt/  # vendored tet mesh optimizer (built as static lib)
+external_includes/  # mesher wrappers (Triangle/TetGen interface headers + .cpp)
+custom_python/      # bindings: add_meshers/add_processes/add_custom_io/add_custom_utilities
+python_scripts/
+  mmg_process.py                       # Python wrapper around the C++ MmgProcess
+  multiscale_refining_process.py
+  gradual_variable_interpolation_process.py
+  modelers/                            # Modeler-based meshing helpers
+tests/
+  cpp_tests/   # GTest + meshing_fast_suite.{h,cpp}
+  test_MeshingApplication.py
+```
+
+## Build
+
+- CMake libs: `KratosMeshingCore` (SHARED) and `KratosMeshingApplication` (pybind11).
+- Compile definition: `MESHING_APPLICATION=EXPORT,API`.
+- `tetMeshOpt` is always built as an extra static lib and linked into `KratosMeshingCore`.
+- Conditional sources:
+  - `INCLUDE_MMG=ON` adds `custom_utilities/mmg/*`, `custom_processes/mmg/*`,
+    `custom_io/mmg/*`, defines `-DINCLUDE_MMG`, and `find_package`s MMG/MMG2D/MMG3D/MMGS.
+    Set `MMG_ROOT` to the MMG build dir if CMake can't auto-locate it.
+  - `INCLUDE_PMMG=ON` adds `custom_utilities/parmmg/*` and `custom_processes/parmmg/*`,
+    defines `-DINCLUDE_PMMG`; **fails configure** if `USE_MPI=OFF` or MMG is not enabled.
+- **Unity-build gotcha:** `mmg/mmg_utilities.cpp` and `parmmg/pmmg_utilities.cpp` are excluded
+  from unity builds (MMG headers are not unity-compatible). Keep that exclusion.
+- C++ tests use `USE_CUSTOM_MAIN`.
+- `python_registry_lists.py` is installed alongside the package `__init__.py`.
+
+## Python usage
+
+- **MMG remeshing:** `mmg_process.py` → `MmgProcess` wraps the C++ `MmgProcess2D/3D/Surfaces`.
+  Typically combined with a metric process (`ComputeLevelSetSolMetricProcess`,
+  `ComputeHessianSolMetricProcess`, `MetricErrorProcess`) that fills `METRIC_TENSOR_*`/`NODAL_H`,
+  then the remesher acts via `Execute()`.
+- **Multiscale refinement:** `multiscale_refining_process.py`.
+- Configure via `Parameters` (JSON); see `mmg_process.py` defaults and `normal_distribution.json`.
+
+## Testing
+
+- **C++ fixture:** `KratosMeshingFastSuite` (`meshing_fast_suite.h`); core-only tests use
+  `KratosCoreFastSuite`.
+- **Python:** `test_MeshingApplication.py` — register new `test_*.py` there. MMG/ParMMG tests
+  are skipped automatically when those libraries are not compiled in.
+
+## Conventions & gotchas
+
+- MMG/ParMMG code is guarded by `INCLUDE_MMG`/`INCLUDE_PMMG` macros — wrap new MMG-dependent
+  code accordingly so non-MMG builds keep compiling.
+- Interpolation of internal (Gauss-point) variables goes through
+  `internal_variables_interpolation_process` — pick the correct interpolation method
+  (CPT / LST / SF) for the physics.
+- Remeshing rebuilds the `ModelPart`: re-create elements/conditions and re-assign properties;
+  historical and non-historical nodal data are interpolated, not preserved by identity.
+- New variables → `meshing_application_variables.{h,cpp}`.

--- a/applications/MetisApplication/CLAUDE.md
+++ b/applications/MetisApplication/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md — MetisApplication
+
+> Application-specific guidance. Inherits everything in the root `/CLAUDE.md`; only the
+> Metis/partitioning specifics are documented here. Read the root file first for global conventions.
+
+## Purpose
+
+The **MetisApplication** is a thin interface to the
+[METIS](https://github.com/KarypisLab/METIS) graph-partitioning library. Within Kratos it
+**partitions meshes for MPI runs**: it reads the model, builds the nodal/elemental graph,
+calls METIS, and assigns each entity to an MPI partition. It is almost always used together
+with the **TrilinosApplication** (which provides the distributed solvers that consume the
+partition).
+
+The application is organized as a set of **partitioning processes**, each wrapping a different
+algorithm. The most commonly used for FE meshes is
+`metis_divide_heterogeneous_input_process` (handles meshes mixing multiple element types).
+
+## Partitioning processes (`custom_processes/`)
+
+- `metis_divide_heterogeneous_input_process.h` — **the default**; partitions a heterogeneous
+  mesh from an input (e.g. `.mdpa`) based on the nodal graph.
+- `metis_divide_heterogeneous_input_in_memory_process.h` — same, but works on an already-read
+  in-memory model (no re-read from disk).
+- `metis_divide_submodelparts_heterogeneous_input_process.h` — partition respecting
+  sub-model-part structure.
+- `morton_divide_input_to_partitions_process.h` / `morton_partitioning_process.h` —
+  Morton-order (space-filling-curve) partitioning alternative.
+
+## Dependencies
+
+- **KratosCore** + **KratosMPICore**.
+- **METIS** (system library) and its dependency **GKlib**. On Debian/Ubuntu:
+  `sudo apt install libmetis-dev`. Point CMake at a custom build with `METIS_ROOT_DIR`.
+- Built **only** under MPI (`USE_MPI=ON`); pairs with **TrilinosApplication**.
+
+## Directory layout (application-specific)
+
+```
+custom_processes/   # the partitioning processes listed above
+custom_utilities/   # graph-construction / partition helpers around the METIS API
+custom_python/      # bindings: add_processes_to_python.cpp, kratos_metis_python_application.cpp
+test_exemples/      # example input meshes for partitioning
+tests/              # test_MetisApplication.py + cpp_tests (metis_fast_suite.{h,cpp})
+```
+
+> Note: this application has **no `python_scripts/`** of its own — the processes are exposed
+> directly through the C++ bindings and used from other applications' MPI launch scripts.
+
+## Build
+
+- CMake target: `KratosMetisApplication` (pybind11), linked against METIS.
+- Requires `USE_MPI=ON` and METIS to be found. Provide `METIS_ROOT_DIR` (or have
+  `libmetis-dev` installed) so CMake can locate headers + libs.
+- Available via Spack as well (see README) for HPC environments.
+- In the **nightly** MPI CI matrix, not the default PR Linux build.
+
+## Usage
+
+Typical MPI preprocessing flow (from an application's MPI main script):
+
+```python
+import KratosMultiphysics as KM
+import KratosMultiphysics.MetisApplication as KratosMetis
+import KratosMultiphysics.mpi as KratosMPI
+
+# read serial-or-distributed input, then partition
+partitioner = KratosMetis.MetisDivideHeterogeneousInputProcess(io, number_of_partitions, ...)
+partitioner.Execute()
+```
+
+In current Kratos the partitioning is usually invoked through the **distributed import**
+machinery (`DistributedImportModelPartUtility` in the MPI core), which selects a Metis
+partitioning process under the hood. Prefer that path over calling the process manually.
+
+## Testing
+
+- **C++ fixture:** `KratosMetisFastSuite` (`metis_fast_suite.h`); generic tests use
+  `KratosCoreFastSuite`. These are MPI GTests.
+- **Python:** `test_MetisApplication.py` is the suite entry point — register new `test_*.py`
+  there. Run under `mpiexec` with `OMP_NUM_THREADS=1` to match CI.
+
+## Conventions & gotchas
+
+- This app **produces partitions, it does not solve** — the distributed solve is done by
+  TrilinosApplication. An MPI run needs both.
+- The graph is built from the mesh connectivity; for heterogeneous (mixed-element) meshes use
+  the `heterogeneous` process, not a homogeneous-only variant.
+- METIS is an **external dependency** — do not vendor or modify it; respect the
+  `METIS_ROOT_DIR` discovery path.
+- Keep partition results deterministic where CI relies on it (METIS seeding / options).

--- a/applications/StructuralMechanicsApplication/CLAUDE.md
+++ b/applications/StructuralMechanicsApplication/CLAUDE.md
@@ -1,0 +1,103 @@
+# CLAUDE.md — StructuralMechanicsApplication
+
+> Application-specific guidance. Inherits everything in the root `/CLAUDE.md`; only the
+> structural-mechanics specifics are documented here. Read the root file first for global
+> C++/Python/pybind11/testing conventions.
+
+## Purpose
+
+The **StructuralMechanicsApplication** provides the finite-element toolbox for solid and
+structural mechanics in Kratos: solid elements (small/large strain), structural elements
+(trusses, beams, cables, shells, membranes), Neumann/contact conditions, the solving
+strategies and schemes that drive static, dynamic, eigenvalue, harmonic, formfinding,
+prebuckling and adjoint analyses, plus the supporting utilities and response functions.
+
+The actual material models (plasticity, damage, hyperelasticity, composites, …) live in
+the sibling **ConstitutiveLawsApplication**; this application contains only a small set of
+"elastic" base laws plus the constitutive-law *infrastructure* (`constitutive_law_utilities.cpp`).
+
+## Dependencies
+
+- **KratosCore** (always).
+- **ConstitutiveLawsApplication** — strongly recommended companion; most material models live there.
+- **LinearSolversApplication** — for eigenvalue / dense solvers used by eigen, harmonic and prebuckling analyses.
+- **TrilinosApplication + MetisApplication** — only for the MPI (`trilinos_*`) solvers and convergence-criteria factories.
+- Optional: **MeshingApplication** — adaptive remeshing solvers (`adaptative_remeshing_*`).
+
+## Directory layout (application-specific)
+
+```
+custom_elements/
+  solid_elements/      # small-displacement, total/updated Lagrangian, mixed (Bbar, U-eps, Q1P0, U-dV/V), SPrism solid-shell
+  truss_elements/      # truss + cable (3D)
+  beam_elements/       # corotational beam (2D/3D)
+  membrane_elements/   # prestressed membrane, formfinding
+  shell_elements/      # thin/thick quad & triangle shells
+  nodal_elements/      # nodal concentrated mass/stiffness/damping, spring-damper
+custom_conditions/     # point/line/surface loads, point moment, distributed, contact
+custom_constitutive/   # elastic base laws + constitutive-law plumbing (flat dir, no subdirs)
+custom_constraints/    # MPC-style structural constraints (e.g. link constraint)
+custom_processes/      # structural processes (see python_scripts wrappers too)
+custom_strategies/     # strategies, schemes, convergence criteria, builder-and-solvers
+custom_response_functions/  # adjoint sensitivity response functions (mass, displacement, stress, …)
+custom_io/             # specialized I/O
+custom_utilities/      # constitutive_law_utilities.cpp (compiled FIRST — see CMake note), structural math helpers
+custom_python/         # pybind11 bindings (one add_custom_*_to_python.cpp per category)
+automatic_differentiation/  # sympy scripts that generate element/constitutive code
+python_scripts/        # analysis stages, solvers, processes (see below)
+benchmarks/            # Google Benchmark files (built with KRATOS_BUILD_BENCHMARK=ON)
+tests/
+  cpp_tests/           # GTest sources + structural_mechanics_fast_suite.{h,cpp}
+  test_StructuralMechanicsApplication.py  # Python suite entry point
+```
+
+## Build
+
+- CMake target libs: `KratosStructuralMechanicsCore` (SHARED C++) and
+  `KratosStructuralMechanicsApplication` (pybind11 module).
+- Sources are auto-globbed via `file(GLOB_RECURSE ...)` over `custom_*` — **new `.cpp`
+  files are picked up automatically**, no CMake edit needed.
+- **Gotcha:** `custom_utilities/constitutive_law_utilities.cpp` is explicitly removed and
+  re-inserted at position 0 of the source list so it compiles first. Do not reorder this.
+- Compile definition: `STRUCTURAL_MECHANICS_APPLICATION=EXPORT,API`.
+- C++ tests built when `KRATOS_BUILD_TESTING=ON` via `kratos_add_gtests(TARGET KratosStructuralMechanicsCore ...)`.
+
+## Python entry points
+
+- **Analysis stage:** `structural_mechanics_analysis.py` → `StructuralMechanicsAnalysis`
+  (inherit from this for custom drivers). Main script: `kratos_main_structural.py`.
+- **Solver wrapper / factory:** `python_solvers_wrapper_structural.py` selects the solver
+  from `solver_settings["solver_type"]`. Solver base: `structural_mechanics_solver.py`
+  (`MechanicalSolver`).
+- **Solver families** (each a `*_solver.py`):
+  - `static`, `implicit_dynamic`, `explicit_dynamic`
+  - `eigensolver` (modal), `harmonic_analysis_solver`, `prebuckling` (+ `prebuckling_analysis`)
+  - `formfinding_solver`, `custom_scipy_base_solver`, `static_shifted_boundary_solver`
+  - `adjoint_static_solver` (sensitivities, pairs with `custom_response_functions/`)
+  - `trilinos_*` variants for MPI
+  - `adaptative_remeshing_*` (needs MeshingApplication)
+- Use `Parameters` (JSON `ProjectParameters.json` + `StructuralMaterials.json`) — never hardcode.
+
+## Testing
+
+- **C++ fixture:** `KratosStructuralMechanicsFastSuite` (in `structural_mechanics_fast_suite.h`).
+  Some core-only tests use `KratosCoreFastSuite`.
+- **Python:** `test_StructuralMechanicsApplication.py` assembles `smallSuite`, `nightSuite`,
+  `validationSuite`, `allSuite`. **Adding a new `test_*.py` requires registering it in this runner.**
+- Run most-specific first: a single GTest filter or single Python test, then the small suite.
+
+## Conventions & gotchas
+
+- Elements/Conditions use `KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION`; Processes/Utilities/
+  Strategies use `KRATOS_CLASS_POINTER_DEFINITION`.
+- Override the four required element/condition virtuals (`CalculateLocalSystem`,
+  `EquationIdVector`, `GetDofList`, `Check`).
+- New global `Variable`s: declare with `KRATOS_DEFINE_APPLICATION_VARIABLE` in
+  `structural_mechanics_application_variables.h`, register with `KRATOS_REGISTER_VARIABLE`
+  in `structural_mechanics_application.cpp`, and register new elements/conditions/laws in
+  the same `.cpp` (`KRATOS_REGISTER_ELEMENT` / `_CONDITION` / `_CONSTITUTIVE_LAW`).
+- Several elements/constitutive laws are **symbolically generated** — edit the generator in
+  `automatic_differentiation/` (or `symbolic_generation`) and regenerate, do not hand-patch
+  the generated body if a generator exists.
+- Local axes for orthotropy are set via the `set_*_local_axes_process.py` processes.
+- DOFs: `DISPLACEMENT`(+`ROTATION` for beams/shells), `VELOCITY`/`ACCELERATION` for dynamics.

--- a/applications/TrilinosApplication/CLAUDE.md
+++ b/applications/TrilinosApplication/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md — TrilinosApplication
+
+> Application-specific guidance. Inherits everything in the root `/CLAUDE.md`; only the
+> Trilinos/MPI specifics are documented here. Read the root file first for global conventions.
+
+## Purpose
+
+The **TrilinosApplication** is the backbone of Kratos's **distributed-memory (MPI)**
+capabilities. It wraps the [Trilinos](https://trilinos.org/) project to provide
+**distributed matrices/vectors** (Epetra) and **parallel linear solvers** (AztecOO, Amesos,
+Amesos2, ML), plus the **MPI versions of the core Kratos solving machinery** (builder-and-
+solvers, strategies, schemes, convergence criteria) adapted to Epetra. It also exposes an MPI
+build of **AMGCL**.
+
+In practice, other applications' `trilinos_*` solvers (Fluid, Structural, Mapping's MPI
+extension, …) are built on top of the classes registered here. This application **only builds
+under MPI** (`USE_MPI=ON` and Trilinos found).
+
+## Provided components (C++ → Python)
+
+- **Spaces:** `TrilinosSpace` (Epetra-backed `Space` abstraction), experimental space.
+- **Linear solvers:** `TrilinosLinearSolver`, `AztecSolver`, `AmesosSolver`, `Amesos2Solver`,
+  `MultiLevelSolver` (ML), and the MPI AMGCL solver.
+- **Builder-and-solvers:** `TrilinosResidualBasedBuilderAndSolver`,
+  `TrilinosBlockBuilderAndSolver(Periodic)`, `TrilinosEliminationBuilderAndSolver`.
+- **Strategies:** `TrilinosLinearStrategy`, `TrilinosNewtonRaphsonStrategy`, `TrilinosSolvingStrategy`.
+- **Schemes** and **convergence criteria:** MPI counterparts of the core
+  (`TrilinosResidualCriteria`, `TrilinosDisplacementCriteria`, `TrilinosAnd/OrCriteria`,
+  `TrilinosMixedGenericCriteria`).
+- These mirror the serial classes (without the `Trilinos` prefix) — consult the serial docs
+  for behavioral semantics.
+
+## Dependencies
+
+- **KratosCore** + **KratosMPICore** (the MPI part of the core).
+- **Trilinos** (system install) — Epetra, Teuchos, AztecOO, Amesos, Amesos2, ML.
+- **MetisApplication** — almost always used together to partition the mesh for MPI runs.
+- Built **only** when `USE_MPI=ON` and `TRILINOS_FOUND`.
+
+## Directory layout (application-specific)
+
+```
+custom_factories/    # trilinos linear-solver factory (registers the solvers above)
+custom_strategies/   # MPI strategies, schemes, builder-and-solvers, convergence criteria
+custom_processes/    # MPI-aware processes
+custom_utilities/    # Epetra/Trilinos helpers, parallel fill-comm utilities
+external_includes/   # thin wrappers over Aztec/Amesos/ML headers
+custom_python/       # bindings, split per category:
+  add_trilinos_space_to_python, add_trilinos_linear_solvers_to_python,
+  add_trilinos_strategies_to_python, add_trilinos_schemes_to_python,
+  add_trilinos_convergence_criterias_to_python, add_trilinos_convergence_accelerators_to_python,
+  add_trilinos_processes_to_python, add_custom_utilities_to_python
+  trilinos_pointer_wrapper.h   # shared/raw pointer interop helper for Trilinos objects
+python_scripts/      # trilinos_linear_solver_factory.py, MonolithicMultiLevelSolver.py,
+                     # PressureMultiLevelSolver.py, gid_output_process_mpi.py
+tests/               # test_TrilinosApplication_mpi.py + test_trilinos_* (matrix, solvers, redistance, …)
+  cpp_tests/         # GTest (MPI) + trilinos_fast_suite.{h,cpp}
+```
+
+## Build
+
+- CMake libs: `KratosTrilinosCore` (SHARED) and `KratosTrilinosApplication` (pybind11),
+  linked against `KratosMPICore` and the Trilinos libraries.
+- Requires `USE_MPI=ON`; CMake must locate Trilinos (`TRILINOS_ROOT` / standard find).
+- This application is in the **nightly** MPI CI matrix, not the default PR Linux build.
+
+## Python usage
+
+- `trilinos_linear_solver_factory.py` constructs distributed solvers from
+  `linear_solver_settings` (`solver_type`: `amesos`, `aztec`, `multi_level`, `amgcl`, …).
+- Other applications select their `trilinos_*` solver wrappers (e.g.
+  `trilinos_navier_stokes_solver_vmsmonolithic.py`), which internally use these classes.
+- Typical MPI run: partition with MetisApplication → solve with a `Trilinos*Strategy` +
+  `TrilinosBlockBuilderAndSolver` + a Trilinos linear solver.
+
+## Testing
+
+- **C++ fixtures:** `KratosMPICoreFastSuite` / `KratosTrilinosApplicationMPITestSuite`
+  (`trilinos_fast_suite.h`) — these are **MPI GTest suites** (run under `mpiexec`).
+- **Python:** `test_TrilinosApplication_mpi.py` is the MPI suite entry point (there is no
+  serial `test_TrilinosApplication.py`). Register new MPI tests there.
+- Run MPI tests with `OMP_NUM_THREADS=1` to match CI, under `mpiexec -np <N>`.
+
+## Conventions & gotchas
+
+- All matrix/vector work goes through `TrilinosSpace` (Epetra) — never assume the serial
+  `UblasSpace` types in MPI code paths.
+- Keep `Trilinos*` classes behaviorally in sync with their serial counterparts; this is a
+  parallel re-implementation layer, not a place for new physics.
+- Use `trilinos_pointer_wrapper.h` for shared/raw pointer interop with Trilinos objects.
+- **Do not modify Trilinos itself** — it is an external system dependency.
+- Pair with MetisApplication for partitioning; an MPI run without a partition is ill-defined.


### PR DESCRIPTION

---
name: ✨ Feature
about:  Add `CLAUDE.md` documentation for various applications

---

## **📝 Description**

 Add `CLAUDE.md` documentation for various applications.

### **Key changes**

- ConstitutiveLawsApplication: Documented purpose, dependencies, directory layout, build instructions, authoring guidelines, registration, testing, and conventions.
- FluidDynamicsApplication: Provided details on purpose, dependencies, directory structure, build process, Python entry points, testing, and conventions.
- LinearSolversApplication: Added information on purpose, provided solvers, dependencies, directory layout, build instructions, Python usage, testing, and conventions.
- MappingApplication: Documented purpose, dependencies, directory layout, build instructions, Python usage, testing, and conventions.
- MeshingApplication: Added details on purpose, dependencies, directory structure, build instructions, Python usage, testing, and conventions.
- MetisApplication: Documented purpose, partitioning processes, dependencies, directory layout, build instructions, usage, testing, and conventions.
- StructuralMechanicsApplication: Provided comprehensive documentation on purpose, dependencies, directory layout, build instructions, Python entry points, testing, and conventions.
- TrilinosApplication: Added information on purpose, provided components, dependencies, directory layout, build instructions, Python usage, testing, and conventions.
 
## **🆕 Changelog**

-  Add `CLAUDE.md` documentation for various applications
